### PR TITLE
Fix: haptic feedback firing continuously upon dragging the slider

### DIFF
--- a/iOS/UI/Reader/ReaderToolbarView.swift
+++ b/iOS/UI/Reader/ReaderToolbarView.swift
@@ -8,7 +8,19 @@
 import UIKit
 
 class ReaderToolbarView: UIView {
-    var currentPageLabelVal: Int?
+    var currentPageValue: Int? {
+        didSet {
+            if previousPageValue != currentPageValue {
+                previousPageValue = currentPageValue
+            }
+        }
+    }
+    var previousPageValue: Int? {
+        willSet {
+            let feedbackGenerator = UISelectionFeedbackGenerator()
+            feedbackGenerator.selectionChanged()
+        }
+    }
     var currentPage: Int? {
         didSet { updatePageLabels() }
     }
@@ -84,6 +96,7 @@ class ReaderToolbarView: UIView {
             page = 1
         }
         currentPageLabel.text = String(format: NSLocalizedString("%i_OF_%i", comment: ""), page, totalPages)
+        currentPageValue = page
     }
 
     func updatePageLabels() {
@@ -99,7 +112,6 @@ class ReaderToolbarView: UIView {
             currentPage = 1
         }
         let pagesLeft = totalPages - currentPage
-        currentPageLabelVal = currentPage
         currentPageLabel.text = String(format: NSLocalizedString("%i_OF_%i", comment: ""), currentPage, totalPages)
         if pagesLeft < 1 {
             pagesLeftLabel.text = nil

--- a/iOS/UI/Reader/ReaderViewController.swift
+++ b/iOS/UI/Reader/ReaderViewController.swift
@@ -393,10 +393,6 @@ extension ReaderViewController: ReaderHoldingDelegate {
 
     func displayPage(_ page: Int) {
         toolbarView.displayPage(page)
-        if toolbarView.currentPageLabelVal != page {
-            let feedbackGenerator = UISelectionFeedbackGenerator()
-            feedbackGenerator.selectionChanged()
-        }
     }
 
     func setCompleted() {


### PR DESCRIPTION
Fixes the issue as described by the title. With this fix, haptic feedback will be triggered only when the current page label value is changed.

I'm also quite new to Swift, so I'm gonna jot down my observations in this PR for self-learning purposes😆.

Observations I made whilst fixing this issue:
- `updatePageLabels()` is only called when the slider is released
- `displayPage()` @ `ReaderToolbarView` is always called whenever the slider is dragged
  - meaning that `currentPageLabel` is always updated whenever the slider is dragged
- `displayPage()` @ `ReaderViewController` is perhaps the page itself in the viewer instead of the label (?)

Also changed the variable name for clarity... still not sure if it's clear enough though💩